### PR TITLE
Update Marimo configuration and URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,11 @@ DATABASE_PORT=5432
 # Caddy settings
 DOMAIN_NAME=localhost
 
+# Marimo settings
+MARIMO_SERVICE_URL=http://127.0.0.1:8080
+MARIMO_EDITOR_URL=http://127.0.0.1:8082
+DJANGO_API_URL=http://web:8000
+
 # Email settings
 EMAIL_HOST=smtp.gmail.com
 EMAIL_PORT=587

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,41 @@ services:
       - "8000:8000"
     env_file:
       - ./.env
+    environment:
+      MARIMO_SERVICE_URL: ${MARIMO_SERVICE_URL:-http://127.0.0.1:8080}
+      MARIMO_EDITOR_URL: ${MARIMO_EDITOR_URL:-http://127.0.0.1:8082}
     depends_on:
       - db
+
+  marimo-run:
+    build: .
+    command: marimo run lab/notebooks --host 0.0.0.0 --port 8080 --headless --no-token
+    volumes:
+      - .:/app:z
+    ports:
+      - "8080:8080"
+    env_file:
+      - ./.env
+    environment:
+      DJANGO_SECRET_KEY: ${SECRET_KEY}
+      DJANGO_API_URL: ${DJANGO_API_URL:-http://web:8000}
+    depends_on:
+      - web
+
+  marimo-edit:
+    build: .
+    command: marimo edit lab/notebooks --host 0.0.0.0 --port 8082 --headless --no-token
+    volumes:
+      - .:/app:z
+    ports:
+      - "8082:8082"
+    env_file:
+      - ./.env
+    environment:
+      DJANGO_SECRET_KEY: ${SECRET_KEY}
+      DJANGO_API_URL: ${DJANGO_API_URL:-http://web:8000}
+    depends_on:
+      - web
 
   caddy:
     image: docker.io/library/caddy:2
@@ -17,7 +50,7 @@ services:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - .:/app:z
     ports:
-      - "8080:80"
+      - "8083:80"
       - "8443:443"
     depends_on:
       - web

--- a/lab/notebooks/_utils.py
+++ b/lab/notebooks/_utils.py
@@ -97,7 +97,7 @@ def auth_prompt_mo(mo):
         f"This notebook calls Django’s `/api/plot-data/` API. "
         f"You need a JWT in the page URL (`token=…`) or in the environment.\n\n"
         f"{run_hint}"
-        f"**Edit in Marimo (e.g. port 8081):** [Open with editor token via Django]({auth_url}) — "
+        f"**Edit in Marimo (e.g. port 8082):** [Open with editor token via Django]({auth_url}) — "
         f"log in if asked, then you’ll return here with `token` set.{mode}\n\n"
         f"**Local dev:** export a JWT and re-run cells:\n"
         f"```bash\n"

--- a/lab/templates/admin/lab/plottemplate/change_form.html
+++ b/lab/templates/admin/lab/plottemplate/change_form.html
@@ -49,7 +49,7 @@ document.addEventListener('DOMContentLoaded', function() {
     <a href="{% url 'lab:marimo_proxy' %}?file={{ original.notebook_filename|urlencode }}&show_download_menu={{ original.show_download_menu|yesno:'1,0' }}"
        class="button"
        target="_blank" rel="noopener noreferrer">Open “{{ original.notebook_filename }}” in Marimo editor</a>
-    <p class="help" style="margin-top:8px;">Runs against <code>MARIMO_EDITOR_URL</code> with a staff token in the redirect URL. Start the editor with <code>marimo edit lab/notebooks/ --port 8081 --host 127.0.0.1 --no-token</code> so Marimo does not show its own password gate.</p>
+    <p class="help" style="margin-top:8px;">Runs against <code>MARIMO_EDITOR_URL</code> with a staff token in the redirect URL. Start the editor with <code>marimo edit lab/notebooks/ --port 8082 --host 127.0.0.1 --no-token</code> so Marimo does not show its own password gate.</p>
 </div>
 {% endif %}
 

--- a/lab/views.py
+++ b/lab/views.py
@@ -2076,11 +2076,11 @@ def marimo_proxy(request, path=""):
     Send staff to the local Marimo *edit* server with a long-lived JWT on the query string.
 
     Use GET params Marimo understands (e.g. file=status_bar.py). Cross-origin cookies do not
-    reach :8081, so the token is carried in the URL; notebooks read it via mo.query_params().
+    reach the Marimo editor port, so the token is carried in the URL; notebooks read it via mo.query_params().
     """
     from .jwt_utils import issue_editor_plot_token
 
-    marimo_base = getattr(settings, "MARIMO_EDITOR_URL", "http://127.0.0.1:8081").rstrip("/")
+    marimo_base = getattr(settings, "MARIMO_EDITOR_URL", "http://127.0.0.1:8082").rstrip("/")
     params = request.GET.copy()
     params["token"] = issue_editor_plot_token(request.user)
     return redirect(f"{marimo_base}/?{params.urlencode()}")

--- a/rareindex/settings.py
+++ b/rareindex/settings.py
@@ -48,7 +48,7 @@ MARIMO_SERVICE_URL = env("MARIMO_SERVICE_URL", default="http://127.0.0.1:8080")
 # Plot JWT lifetime for dashboard iframes (seconds). Keep > typical Marimo boot + cell run time.
 MARIMO_PLOT_TOKEN_MAX_AGE = env.int("MARIMO_PLOT_TOKEN_MAX_AGE", default=900)
 # `marimo edit` (staff opens via /authoring/marimo/ — receives a long-lived JWT in the redirect URL)
-MARIMO_EDITOR_URL = env("MARIMO_EDITOR_URL", default="http://127.0.0.1:8081")
+MARIMO_EDITOR_URL = env("MARIMO_EDITOR_URL", default="http://127.0.0.1:8082")
 MARIMO_EDITOR_TOKEN_MAX_AGE = env.int("MARIMO_EDITOR_TOKEN_MAX_AGE", default=28800)
 
 


### PR DESCRIPTION
- Added Marimo service and editor URLs to the .env.example file.
- Updated docker-compose.yml to include new services for Marimo with appropriate environment variables.
- Changed default Marimo editor URL from port 8081 to 8082 in settings and views.
- Updated documentation in change_form.html to reflect the new editor port.