### PR TITLE
Add FHIR and Phenopacket export functionality

### DIFF
--- a/lab/export_formats.py
+++ b/lab/export_formats.py
@@ -1,0 +1,461 @@
+import re
+import uuid
+from datetime import date, datetime, timezone as datetime_timezone
+
+from django.utils import timezone
+
+
+FHIR_IDENTIFIER_SYSTEM = "https://rareindex.local/fhir/identifier-type"
+FHIR_HPO_SYSTEM = "http://purl.obolibrary.org/obo/hp.owl"
+FHIR_ICD11_SYSTEM = "http://id.who.int/icd/release/11/mms"
+
+PHENOPACKET_SCHEMA_VERSION = "2.0"
+
+
+def build_fhir_bundle(individual, user, created_at=None):
+    """Build a compact FHIR JSON Bundle for a RareIndex individual."""
+    created_at = created_at or timezone.now()
+    patient_ref = _fhir_full_url("Patient", individual.pk)
+
+    bundle = {
+        "resourceType": "Bundle",
+        "type": "collection",
+        "timestamp": _datetime_to_instant(created_at),
+        "entry": [
+            {
+                "fullUrl": patient_ref,
+                "resource": _build_fhir_patient(individual, user),
+            }
+        ],
+    }
+
+    condition_ref = None
+    condition = _build_fhir_condition(individual, patient_ref)
+    if condition:
+        condition_ref = _fhir_full_url("Condition", individual.pk)
+        bundle["entry"].append({"fullUrl": condition_ref, "resource": condition})
+
+    for term in individual.hpo_terms.all():
+        observation_ref = _fhir_full_url("Observation", f"{individual.pk}-{term.pk}")
+        bundle["entry"].append(
+            {
+                "fullUrl": observation_ref,
+                "resource": _build_fhir_phenotype_observation(
+                    individual,
+                    term,
+                    patient_ref,
+                    condition_ref,
+                ),
+            }
+        )
+
+    for sample in individual.samples.all():
+        specimen_ref = _fhir_full_url("Specimen", sample.pk)
+        bundle["entry"].append(
+            {
+                "fullUrl": specimen_ref,
+                "resource": _build_fhir_specimen(sample, patient_ref),
+            }
+        )
+
+    return _compact(bundle)
+
+
+def build_phenopacket(individual, user, created_at=None):
+    """Build a Phenopacket v2 JSON object for a RareIndex individual."""
+    created_at = created_at or timezone.now()
+    subject_id = _phenopacket_subject_id(individual)
+    resources = [_phenopacket_rareindex_resource()]
+
+    hpo_terms = list(individual.hpo_terms.all())
+    if hpo_terms:
+        resources.append(_phenopacket_hpo_resource(hpo_terms[0].ontology))
+
+    if individual.icd11_code:
+        resources.append(_phenopacket_icd11_resource())
+
+    packet = {
+        "id": f"phenopacket-{individual.pk}",
+        "subject": _build_phenopacket_subject(individual, user, subject_id),
+        "phenotypicFeatures": [
+            {"type": _phenopacket_ontology_class(term)}
+            for term in hpo_terms
+        ],
+        "diseases": _build_phenopacket_diseases(individual),
+        "biosamples": [
+            _build_phenopacket_biosample(sample, subject_id)
+            for sample in individual.samples.all()
+        ],
+        "metaData": {
+            "created": _datetime_to_instant(created_at),
+            "createdBy": _created_by(user),
+            "resources": resources,
+            "phenopacketSchemaVersion": PHENOPACKET_SCHEMA_VERSION,
+        },
+    }
+    return _compact(packet)
+
+
+def _build_fhir_patient(individual, user):
+    include_sensitive = _can_view_sensitive(user)
+    identifiers = [
+        _build_fhir_identifier(cross_id)
+        for cross_id in individual.cross_ids.all()
+        if cross_id.id_value
+    ]
+
+    if include_sensitive and individual.tc_identity:
+        identifiers.append(
+            {
+                "type": {"text": "TC Identity"},
+                "value": str(individual.tc_identity),
+            }
+        )
+
+    patient = {
+        "resourceType": "Patient",
+        "id": _fhir_id("individual", individual.pk),
+        "identifier": identifiers,
+        "gender": _fhir_gender(individual.sex),
+        "birthDate": individual.birth_date.isoformat()
+        if include_sensitive and individual.birth_date
+        else None,
+        "deceasedBoolean": True if not individual.is_alive else None,
+        "name": [{"text": individual.full_name}]
+        if include_sensitive and individual.full_name
+        else None,
+    }
+    return _compact(patient)
+
+
+def _build_fhir_condition(individual, patient_ref):
+    if not individual.diagnosis and not individual.icd11_code:
+        return None
+
+    code = {
+        "coding": [
+            {
+                "system": FHIR_ICD11_SYSTEM,
+                "code": individual.icd11_code,
+                "display": individual.diagnosis or None,
+            }
+        ]
+        if individual.icd11_code
+        else [],
+        "text": individual.diagnosis or individual.icd11_code,
+    }
+
+    condition = {
+        "resourceType": "Condition",
+        "id": _fhir_id("condition", individual.pk),
+        "clinicalStatus": _fhir_codeable_concept(
+            "http://terminology.hl7.org/CodeSystem/condition-clinical",
+            "active" if individual.is_affected else "unknown",
+            "Active" if individual.is_affected else "Unknown",
+        ),
+        "verificationStatus": _fhir_codeable_concept(
+            "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+            "confirmed" if individual.diagnosis_date else "provisional",
+            "Confirmed" if individual.diagnosis_date else "Provisional",
+        ),
+        "code": code,
+        "subject": {"reference": patient_ref},
+        "recordedDate": individual.diagnosis_date.isoformat()
+        if individual.diagnosis_date
+        else None,
+    }
+
+    onset_age = _fhir_onset_age(individual.age_of_onset_in_months)
+    if onset_age:
+        condition["onsetAge"] = onset_age
+    elif individual.age_of_onset:
+        condition["onsetString"] = individual.age_of_onset
+
+    return _compact(condition)
+
+
+def _build_fhir_phenotype_observation(individual, term, patient_ref, condition_ref):
+    observation = {
+        "resourceType": "Observation",
+        "id": _fhir_id("phenotype", f"{individual.pk}-{term.pk}"),
+        "status": "final",
+        "category": [
+            _fhir_codeable_concept(
+                "http://terminology.hl7.org/CodeSystem/observation-category",
+                "exam",
+                "Exam",
+            )
+        ],
+        "code": _fhir_ontology_codeable_concept(term),
+        "subject": {"reference": patient_ref},
+        "focus": [{"reference": condition_ref}] if condition_ref else None,
+        "dataAbsentReason": _fhir_codeable_concept(
+            "http://terminology.hl7.org/CodeSystem/data-absent-reason",
+            "clinical-finding",
+            "Clinical Finding",
+        ),
+        "note": [{"text": term.description}] if term.description else None,
+    }
+    return _compact(observation)
+
+
+def _build_fhir_specimen(sample, patient_ref):
+    notes = []
+    if sample.sample_measurements:
+        notes.append({"text": sample.sample_measurements})
+
+    specimen = {
+        "resourceType": "Specimen",
+        "id": _fhir_id("sample", sample.pk),
+        "subject": {"reference": patient_ref},
+        "type": {"text": sample.sample_type.name if sample.sample_type else None},
+        "receivedTime": sample.receipt_date.isoformat()
+        if sample.receipt_date
+        else None,
+        "note": notes,
+    }
+    return _compact(specimen)
+
+
+def _build_fhir_identifier(cross_id):
+    identifier = {
+        "system": f"{FHIR_IDENTIFIER_SYSTEM}/{cross_id.id_type_id}",
+        "value": cross_id.id_value,
+        "type": {"text": cross_id.id_type.name},
+        "assigner": {"display": cross_id.id_type.name},
+    }
+    if cross_id.id_type.use_priority == 1:
+        identifier["use"] = "usual"
+    elif cross_id.id_type.use_priority > 1:
+        identifier["use"] = "secondary"
+    return _compact(identifier)
+
+
+def _build_phenopacket_subject(individual, user, subject_id):
+    include_sensitive = _can_view_sensitive(user)
+    subject = {
+        "id": subject_id,
+        "sex": _phenopacket_sex(individual.sex),
+        "dateOfBirth": _date_to_phenopacket_timestamp(individual.birth_date)
+        if include_sensitive and individual.birth_date
+        else None,
+        "vitalStatus": {
+            "status": "ALIVE" if individual.is_alive else "DECEASED",
+        },
+    }
+    return _compact(subject)
+
+
+def _build_phenopacket_diseases(individual):
+    if not individual.diagnosis and not individual.icd11_code:
+        return []
+
+    if individual.icd11_code:
+        disease_term = {
+            "id": f"ICD11:{individual.icd11_code}",
+            "label": individual.diagnosis or individual.icd11_code,
+        }
+    else:
+        disease_term = {
+            "id": f"RI:diagnosis-{individual.pk}",
+            "label": individual.diagnosis,
+        }
+
+    disease = {
+        "term": disease_term,
+        "onset": _phenopacket_age(individual.age_of_onset_in_months),
+    }
+    return [_compact(disease)]
+
+
+def _build_phenopacket_biosample(sample, subject_id):
+    sample_type = None
+    if sample.sample_type:
+        sample_type = {
+            "id": f"RI:sample-type-{sample.sample_type_id}",
+            "label": sample.sample_type.name,
+        }
+
+    biosample = {
+        "id": f"sample-{sample.pk}",
+        "individualId": subject_id,
+        "description": sample.sample_measurements,
+        "sampleType": sample_type,
+        "timeOfCollection": {
+            "timestamp": _date_to_phenopacket_timestamp(sample.receipt_date)
+        }
+        if sample.receipt_date
+        else None,
+    }
+    return _compact(biosample)
+
+
+def _phenopacket_ontology_class(term):
+    return _compact({"id": term.term, "label": term.label})
+
+
+def _phenopacket_rareindex_resource():
+    return {
+        "id": "rareindex",
+        "name": "RareIndex",
+        "url": "https://rareindex.local",
+        "version": "local",
+        "namespacePrefix": "RI",
+        "iriPrefix": "https://rareindex.local/",
+    }
+
+
+def _phenopacket_hpo_resource(ontology):
+    return {
+        "id": "hp",
+        "name": "Human Phenotype Ontology",
+        "url": "http://purl.obolibrary.org/obo/hp.owl",
+        "version": ontology.label or "unknown",
+        "namespacePrefix": "HP",
+        "iriPrefix": "http://purl.obolibrary.org/obo/HP_",
+    }
+
+
+def _phenopacket_icd11_resource():
+    return {
+        "id": "icd11",
+        "name": "International Classification of Diseases 11th Revision",
+        "url": "https://icd.who.int/browse11",
+        "version": "11",
+        "namespacePrefix": "ICD11",
+        "iriPrefix": "https://icd.who.int/browse11/l-m/en#/http://id.who.int/icd/entity/",
+    }
+
+
+def _fhir_ontology_codeable_concept(term):
+    system_by_source = {
+        "HP": FHIR_HPO_SYSTEM,
+        "MONDO": "http://purl.obolibrary.org/obo/mondo.owl",
+        "ONCOTREE": "http://purl.obolibrary.org/obo/ncit/ncit-oncotree.owl",
+    }
+    return _compact(
+        {
+            "coding": [
+                {
+                    "system": system_by_source.get(term.source),
+                    "code": term.term,
+                    "display": term.label,
+                }
+            ],
+            "text": term.label or term.term,
+        }
+    )
+
+
+def _fhir_codeable_concept(system, code, display):
+    return _compact(
+        {
+            "coding": [
+                {
+                    "system": system,
+                    "code": code,
+                    "display": display,
+                }
+            ],
+            "text": display,
+        }
+    )
+
+
+def _fhir_gender(sex):
+    if sex in {"male", "female", "other"}:
+        return sex
+    return "unknown"
+
+
+def _phenopacket_sex(sex):
+    return {
+        "male": "MALE",
+        "female": "FEMALE",
+        "other": "OTHER_SEX",
+    }.get(sex, "UNKNOWN_SEX")
+
+
+def _fhir_onset_age(months):
+    if months is None:
+        return None
+    return {
+        "value": months,
+        "unit": "months",
+        "system": "http://unitsofmeasure.org",
+        "code": "mo",
+    }
+
+
+def _phenopacket_age(months):
+    if months is None:
+        return None
+    return {"age": {"iso8601duration": _months_to_iso8601_duration(months)}}
+
+
+def _months_to_iso8601_duration(months):
+    years, remaining_months = divmod(months, 12)
+    duration = "P"
+    if years:
+        duration += f"{years}Y"
+    if remaining_months:
+        duration += f"{remaining_months}M"
+    return duration if duration != "P" else "P0M"
+
+
+def _fhir_full_url(resource_type, identifier):
+    stable_uuid = uuid.uuid5(uuid.NAMESPACE_URL, f"rareindex:{resource_type}:{identifier}")
+    return f"urn:uuid:{stable_uuid}"
+
+
+def _fhir_id(prefix, identifier):
+    value = re.sub(r"[^A-Za-z0-9.-]+", "-", f"{prefix}-{identifier}").strip("-")
+    return value[:64] or prefix
+
+
+def _phenopacket_subject_id(individual):
+    return f"individual-{individual.pk}"
+
+
+def _created_by(user):
+    if user and getattr(user, "is_authenticated", False):
+        return user.get_username()
+    return "RareIndex"
+
+
+def _can_view_sensitive(user):
+    return bool(user and user.has_perm("lab.view_sensitive_data"))
+
+
+def _datetime_to_instant(value):
+    if timezone.is_naive(value):
+        value = timezone.make_aware(value, datetime_timezone.utc)
+    return value.astimezone(datetime_timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _date_to_phenopacket_timestamp(value):
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return _datetime_to_instant(value)
+    if isinstance(value, date):
+        return f"{value.isoformat()}T00:00:00Z"
+    return None
+
+
+def _compact(value):
+    if isinstance(value, dict):
+        compacted = {}
+        for key, item in value.items():
+            compact_item = _compact(item)
+            if compact_item in (None, "", [], {}):
+                continue
+            compacted[key] = compact_item
+        return compacted
+    if isinstance(value, list):
+        return [
+            compact_item
+            for item in value
+            if (compact_item := _compact(item)) not in (None, "", [], {})
+        ]
+    return value

--- a/lab/templates/lab/partials/tabs/_info.html
+++ b/lab/templates/lab/partials/tabs/_info.html
@@ -1,4 +1,26 @@
 {% load lab_tags %}
+<div class="mb-4 flex flex-wrap justify-end gap-2">
+    {% if perms.lab.view_individual and perms.lab.view_sensitive_data %}
+    <a href="{% url 'lab:individual_export_fhir' individual.pk %}" download hx-boost="false" class="btn btn-outline btn-sm">
+        <i class="fa-solid fa-file-export"></i>
+        Export as FHIR
+    </a>
+    <a href="{% url 'lab:individual_export_phenopacket' individual.pk %}" download hx-boost="false" class="btn btn-outline btn-sm">
+        <i class="fa-solid fa-file-code"></i>
+        Export as Phenopacket
+    </a>
+    {% else %}
+    <button type="button" class="btn btn-outline btn-sm" disabled aria-disabled="true">
+        <i class="fa-solid fa-file-export"></i>
+        Export as FHIR
+    </button>
+    <button type="button" class="btn btn-outline btn-sm" disabled aria-disabled="true">
+        <i class="fa-solid fa-file-code"></i>
+        Export as Phenopacket
+    </button>
+    {% endif %}
+</div>
+
 <div class="grid grid-cols-2 gap-6">
     <div class="card bg-base-100 border border-base-200 shadow-sm" id="projects-card-{{ individual.pk }}">
         <div class="card-body p-4">

--- a/lab/test_clinical_json_exports.py
+++ b/lab/test_clinical_json_exports.py
@@ -1,0 +1,192 @@
+import json
+from datetime import date
+
+from django.contrib.auth.models import Permission, User
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+
+from lab.models import CrossIdentifier, IdentifierType, Individual, Sample, SampleType
+from lab.views import (
+    IndividualDetailView,
+    IndividualFHIRExportView,
+    IndividualPhenopacketExportView,
+)
+from ontologies.models import Ontology, Term
+
+
+class IndividualClinicalJsonExportTest(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(username="exporter", password="password")
+        self.view_permission = Permission.objects.get(codename="view_individual")
+        self.sensitive_permission = Permission.objects.get(codename="view_sensitive_data")
+        self.user.user_permissions.add(self.view_permission, self.sensitive_permission)
+
+        self.ontology = Ontology.objects.create(type=1, label="2024-01-01")
+        self.hpo_term = Term.objects.create(
+            ontology=self.ontology,
+            identifier="0001250",
+            label="Seizure",
+            description="A seizure phenotype.",
+        )
+        self.identifier_type = IdentifierType.objects.create(
+            name="Study ID",
+            use_priority=1,
+            created_by=self.user,
+        )
+        self.sample_type = SampleType.objects.create(name="Blood", created_by=self.user)
+
+        self.individual = Individual.objects.create(
+            full_name="John Doe",
+            tc_identity=12345678901,
+            birth_date=date(2000, 1, 1),
+            sex="male",
+            is_alive=True,
+            is_affected=True,
+            diagnosis="Bethlem myopathy",
+            icd11_code="8C70.0",
+            diagnosis_date=date(2024, 1, 2),
+            age_of_onset_in_months=168,
+            created_by=self.user,
+        )
+        self.individual.hpo_terms.add(self.hpo_term)
+        CrossIdentifier.objects.create(
+            individual=self.individual,
+            id_type=self.identifier_type,
+            id_value="RI-001",
+            created_by=self.user,
+        )
+        Sample.objects.create(
+            individual=self.individual,
+            sample_type=self.sample_type,
+            receipt_date=date(2024, 2, 3),
+            sample_measurements="OD 1.8",
+            created_by=self.user,
+        )
+
+    def test_info_tab_shows_json_export_buttons(self):
+        request = self.factory.get(reverse("lab:individual_detail", args=[self.individual.pk]))
+        request.user = self.user
+        request.htmx = False
+
+        response = IndividualDetailView.as_view()(request, pk=self.individual.pk)
+        response.render()
+        content = response.content.decode()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Export as FHIR", content)
+        self.assertIn(reverse("lab:individual_export_fhir", args=[self.individual.pk]), content)
+        self.assertIn("Export as Phenopacket", content)
+        self.assertIn(reverse("lab:individual_export_phenopacket", args=[self.individual.pk]), content)
+        self.assertEqual(content.count('hx-boost="false"'), 2)
+        self.assertEqual(content.count("download"), 2)
+
+    def test_info_tab_shows_disabled_json_export_buttons_without_both_permissions(self):
+        users = [
+            User.objects.create_user(username="viewonly", password="password"),
+            User.objects.create_user(username="sensitiveonly", password="password"),
+        ]
+        users[0].user_permissions.add(self.view_permission)
+        users[1].user_permissions.add(self.sensitive_permission)
+
+        for user in users:
+            request = self.factory.get(reverse("lab:individual_detail", args=[self.individual.pk]))
+            request.user = user
+            request.htmx = False
+
+            response = IndividualDetailView.as_view()(request, pk=self.individual.pk)
+            response.render()
+            content = response.content.decode()
+
+            self.assertIn("Export as FHIR", content)
+            self.assertIn("Export as Phenopacket", content)
+            self.assertEqual(content.count('aria-disabled="true"'), 2)
+            self.assertNotIn(reverse("lab:individual_export_fhir", args=[self.individual.pk]), content)
+            self.assertNotIn(reverse("lab:individual_export_phenopacket", args=[self.individual.pk]), content)
+
+    def test_fhir_export_downloads_bundle(self):
+        request = self.factory.get(reverse("lab:individual_export_fhir", args=[self.individual.pk]))
+        request.user = self.user
+
+        response = IndividualFHIRExportView.as_view()(request, pk=self.individual.pk)
+        data = json.loads(response.content)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response["Content-Type"].startswith("application/fhir+json"))
+        self.assertIn(f"individual-{self.individual.pk}.fhir.json", response["Content-Disposition"])
+        self.assertEqual(data["resourceType"], "Bundle")
+        self.assertEqual(data["type"], "collection")
+
+        resources = [entry["resource"] for entry in data["entry"]]
+        patient = next(resource for resource in resources if resource["resourceType"] == "Patient")
+        self.assertEqual(patient["gender"], "male")
+        self.assertEqual(patient["birthDate"], "2000-01-01")
+        self.assertEqual(patient["name"][0]["text"], "John Doe")
+        self.assertEqual(patient["identifier"][0]["value"], "RI-001")
+
+        condition = next(resource for resource in resources if resource["resourceType"] == "Condition")
+        self.assertEqual(condition["code"]["coding"][0]["code"], "8C70.0")
+        self.assertEqual(condition["onsetAge"]["value"], 168)
+
+        observation = next(resource for resource in resources if resource["resourceType"] == "Observation")
+        self.assertEqual(observation["code"]["coding"][0]["code"], "HP:0001250")
+
+        specimen = next(resource for resource in resources if resource["resourceType"] == "Specimen")
+        self.assertEqual(specimen["type"]["text"], "Blood")
+
+    def test_fhir_export_requires_both_individual_view_and_sensitive_permissions(self):
+        limited_user = User.objects.create_user(username="limited", password="password")
+        view_only_user = User.objects.create_user(username="viewonly-export", password="password")
+        sensitive_only_user = User.objects.create_user(username="sensitiveonly-export", password="password")
+        view_only_user.user_permissions.add(self.view_permission)
+        sensitive_only_user.user_permissions.add(self.sensitive_permission)
+
+        for user in [limited_user, view_only_user, sensitive_only_user]:
+            request = self.factory.get(reverse("lab:individual_export_fhir", args=[self.individual.pk]))
+            request.user = user
+
+            response = IndividualFHIRExportView.as_view()(request, pk=self.individual.pk)
+
+            self.assertEqual(response.status_code, 403)
+
+    def test_phenopacket_export_requires_both_individual_view_and_sensitive_permissions(self):
+        limited_user = User.objects.create_user(username="limited-phenopacket", password="password")
+        view_only_user = User.objects.create_user(username="viewonly-phenopacket", password="password")
+        sensitive_only_user = User.objects.create_user(username="sensitiveonly-phenopacket", password="password")
+        view_only_user.user_permissions.add(self.view_permission)
+        sensitive_only_user.user_permissions.add(self.sensitive_permission)
+
+        for user in [limited_user, view_only_user, sensitive_only_user]:
+            request = self.factory.get(
+                reverse("lab:individual_export_phenopacket", args=[self.individual.pk])
+            )
+            request.user = user
+
+            response = IndividualPhenopacketExportView.as_view()(request, pk=self.individual.pk)
+
+            self.assertEqual(response.status_code, 403)
+
+    def test_phenopacket_export_downloads_schema_v2_json(self):
+        request = self.factory.get(reverse("lab:individual_export_phenopacket", args=[self.individual.pk]))
+        request.user = self.user
+
+        response = IndividualPhenopacketExportView.as_view()(request, pk=self.individual.pk)
+        data = json.loads(response.content)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response["Content-Type"].startswith("application/json"))
+        self.assertIn(
+            f"individual-{self.individual.pk}.phenopacket.json",
+            response["Content-Disposition"],
+        )
+        self.assertEqual(data["subject"]["sex"], "MALE")
+        self.assertEqual(data["subject"]["dateOfBirth"], "2000-01-01T00:00:00Z")
+        self.assertEqual(data["phenotypicFeatures"][0]["type"]["id"], "HP:0001250")
+        self.assertEqual(data["diseases"][0]["term"]["id"], "ICD11:8C70.0")
+        self.assertEqual(data["diseases"][0]["onset"]["age"]["iso8601duration"], "P14Y")
+        self.assertEqual(data["biosamples"][0]["sampleType"]["label"], "Blood")
+        self.assertEqual(data["metaData"]["phenopacketSchemaVersion"], "2.0")
+        self.assertIn(
+            "hp",
+            {resource["id"] for resource in data["metaData"]["resources"]},
+        )

--- a/lab/urls.py
+++ b/lab/urls.py
@@ -15,6 +15,8 @@ from .views import (
     CompleteTaskView,
     ReopenTaskView,
     IndividualExportView,
+    IndividualFHIRExportView,
+    IndividualPhenopacketExportView,
     configurations_view,
     MapVisualizationView,
     issue_plot_token_view,
@@ -114,6 +116,8 @@ urlpatterns = [
     # Map visualization (current and default at /visualizations/)
     path("visualizations/", MapVisualizationView.as_view(), name="map_visualization"),
     path("individuals/export/", IndividualExportView.as_view(), name="individual_export"),
+    path("individuals/<int:pk>/export/fhir/", IndividualFHIRExportView.as_view(), name="individual_export_fhir"),
+    path("individuals/<int:pk>/export/phenopacket/", IndividualPhenopacketExportView.as_view(), name="individual_export_phenopacket"),
     path("individuals/create-family/", FamilyCreateView.as_view(), name="create_family"),
     path("samples/", SampleListView.as_view(), name="sample_list"),
     path("individuals/<int:pk>/detail/", IndividualDetailView.as_view(), name="individual_detail"),

--- a/lab/views.py
+++ b/lab/views.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import re
 from django.conf import settings
@@ -50,6 +51,7 @@ from .search_utils import (
 )
 from .history_display import format_history_diff, historical_model_name
 from .status_utils import build_status_metadata_by_model
+from .export_formats import build_fhir_bundle, build_phenopacket
 from variant.models import (
     ACMGEvidenceOverride,
     Variant,
@@ -1710,6 +1712,57 @@ class ReopenTaskView(LoginRequiredMixin, TemplateView):
 
 import csv
 from django.views import View
+
+
+def _get_individual_for_json_export(pk):
+    return get_object_or_404(
+        Individual.objects.prefetch_related(
+            "cross_ids",
+            "cross_ids__id_type",
+            "hpo_terms",
+            "hpo_terms__ontology",
+            "samples",
+            "samples__sample_type",
+        ),
+        pk=pk,
+    )
+
+
+def _user_can_export_individual_json(user):
+    return (
+        user.has_perm("lab.view_individual")
+        and user.has_perm("lab.view_sensitive_data")
+    )
+
+
+def _json_download_response(payload, filename, content_type="application/json"):
+    response = HttpResponse(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        content_type=content_type,
+    )
+    response["Content-Disposition"] = f'attachment; filename="{filename}"'
+    return response
+
+
+class IndividualFHIRExportView(LoginRequiredMixin, View):
+    def get(self, request, pk, *args, **kwargs):
+        if not _user_can_export_individual_json(request.user):
+            return HttpResponseForbidden("You do not have permission to export this individual.")
+        individual = _get_individual_for_json_export(pk)
+        payload = build_fhir_bundle(individual, request.user)
+        filename = f"individual-{individual.pk}.fhir.json"
+        return _json_download_response(payload, filename, "application/fhir+json")
+
+
+class IndividualPhenopacketExportView(LoginRequiredMixin, View):
+    def get(self, request, pk, *args, **kwargs):
+        if not _user_can_export_individual_json(request.user):
+            return HttpResponseForbidden("You do not have permission to export this individual.")
+        individual = _get_individual_for_json_export(pk)
+        payload = build_phenopacket(individual, request.user)
+        filename = f"individual-{individual.pk}.phenopacket.json"
+        return _json_download_response(payload, filename)
+
 
 class IndividualExportView(LoginRequiredMixin, View):
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
- Introduced `IndividualFHIRExportView` and `IndividualPhenopacketExportView` for exporting individual data in FHIR and Phenopacket formats, respectively.
- Implemented helper functions to build FHIR bundles and Phenopackets from individual data.
- Updated URLs to include export endpoints for FHIR and Phenopacket.
- Enhanced the individual detail template to display export buttons based on user permissions.
- Added tests to ensure proper functionality of the export views and permissions handling.