### PR TITLE
Add tests for Marimo proxy URL handling and enhance view logic

### DIFF
--- a/lab/test_marimo_proxy.py
+++ b/lab/test_marimo_proxy.py
@@ -32,6 +32,45 @@ class MarimoRunProxyTests(TestCase):
         self.assertIn("token", query)
 
     @override_settings(
+        ALLOWED_HOSTS=["10.100.12.79", "testserver"],
+        MARIMO_SERVICE_URL="/marimo-run",
+        SECURE_SSL_REDIRECT=False,
+    )
+    def test_direct_docker_web_port_redirects_to_exposed_marimo_port(self):
+        response = self.client.get(
+            reverse("lab:marimo_run_proxy"),
+            {"file": "status_bar.py", "show_download_menu": "0"},
+            HTTP_HOST="10.100.12.79:8090",
+        )
+
+        self.assertEqual(response.status_code, 302)
+        location = response["Location"]
+        self.assertTrue(location.startswith("http://10.100.12.79:8091/?"), location)
+
+        query = parse_qs(urlsplit(location).query)
+        self.assertEqual(query["file"], ["status_bar.py"])
+        self.assertEqual(query["show_download_menu"], ["0"])
+        self.assertIn("token", query)
+
+    @override_settings(
+        ALLOWED_HOSTS=["10.100.12.79", "testserver"],
+        MARIMO_SERVICE_URL="http://127.0.0.1:8091",
+        SECURE_SSL_REDIRECT=False,
+    )
+    def test_direct_docker_web_port_with_loopback_config_uses_exposed_marimo_port(self):
+        response = self.client.get(
+            reverse("lab:marimo_run_proxy"),
+            {"file": "status_bar.py"},
+            HTTP_HOST="10.100.12.79:8090",
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(
+            response["Location"].startswith("http://10.100.12.79:8091/?"),
+            response["Location"],
+        )
+
+    @override_settings(
         ALLOWED_HOSTS=["localhost", "testserver"],
         MARIMO_SERVICE_URL="http://127.0.0.1:8091",
     )

--- a/lab/views.py
+++ b/lab/views.py
@@ -77,6 +77,18 @@ def _request_uses_loopback_host(request):
     return _is_loopback_hostname(urlsplit(f"//{request.get_host()}").hostname)
 
 
+def _direct_docker_marimo_base_url(request, target_port):
+    request_parts = urlsplit(f"//{request.get_host()}")
+    if request_parts.port != 8090:
+        return None
+    if not request_parts.hostname:
+        return None
+    host = request_parts.hostname
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    return f"{request.scheme}://{host}:{target_port}"
+
+
 def _browser_marimo_base_url(request, configured_url, proxy_path):
     """
     Return a browser-reachable Marimo base URL.
@@ -87,12 +99,27 @@ def _browser_marimo_base_url(request, configured_url, proxy_path):
     same-origin Caddy proxy path.
     """
     base_url = str(configured_url or "").strip().rstrip("/")
+    proxy_target_port = 8092 if proxy_path == "/marimo-edit" else 8091
     if not base_url:
-        return proxy_path.rstrip("/")
+        return (
+            _direct_docker_marimo_base_url(request, proxy_target_port)
+            or proxy_path.rstrip("/")
+        )
 
     parts = urlsplit(base_url)
+    if not parts.scheme and base_url.startswith("/"):
+        return (
+            _direct_docker_marimo_base_url(request, proxy_target_port)
+            or base_url
+        )
     if parts.scheme and _is_loopback_hostname(parts.hostname):
         if not _request_uses_loopback_host(request):
+            direct_url = _direct_docker_marimo_base_url(
+                request,
+                parts.port or proxy_target_port,
+            )
+            if direct_url:
+                return direct_url
             return proxy_path.rstrip("/")
     return base_url
 


### PR DESCRIPTION
- Introduced tests to validate redirection behavior for direct Docker web port requests.
- Enhanced view logic to determine the correct Marimo base URL based on request context and loopback configurations.
- Implemented helper function to construct direct Docker URLs for improved proxy handling.